### PR TITLE
Change the package name from alchemist to alchemist_py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # alchemist
 
 Alchemist is a Component-Oriented and High-Level-Synthesis (HLS) FPGA Development Environment Based-on DDS (Data Distribution Service).
-It is originally started by @Kenta11 and forked to here.
 
 [日本語版](README-jp.md)
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,37 @@ It is originally started by @Kenta11 and forked to here.
 
 [日本語版](README-jp.md)
 
+
+## Usage
+
+### Creating a new project
+
+```
+$ alchemist new
+```
+
+### Update the project
+
+```
+$ alchemist update
+```
+
+### HLS simulation
+
+#### Unit testing
+
+```
+$ alchemist test --unit
+```
+
+#### Integrated testing
+
+```
+$ alchemist test --integration
+```
+
+### Bitstream generation
+```
+$ alchemist compile
+```
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # alchemist
 
+Alchemist is a Component-Oriented and High-Level-Synthesis (HLS) FPGA Development Environment Based-on DDS (Data Distribution Service).
+It is originally started by @Kenta11 and forked to here.
+
 [日本語版](README-jp.md)
+

--- a/alchemist_py/brokergen.py
+++ b/alchemist_py/brokergen.py
@@ -11,7 +11,7 @@ import toml
 from logzero import logger
 from pathlib import Path
 
-from alchemist.yacc import parser
+from alchemist_py.yacc import parser
 
 def createProject(broker_name:str):
     logger.info("Generating broker: {}".format(broker_name))

--- a/alchemist_py/main.py
+++ b/alchemist_py/main.py
@@ -14,12 +14,12 @@ import toml
 from logzero import logger
 from pathlib import Path
 
-from alchemist.argument_parser import ArgumentParser
-from alchemist.deviceinfo import listDevices
-from alchemist.plugin_manager import PluginManager
-from alchemist.project_manager import Manager
-from alchemist.tclgen import tclgen
-from alchemist.xdcgen import xdcgen
+from alchemist_py.argument_parser import ArgumentParser
+from alchemist_py.deviceinfo import listDevices
+from alchemist_py.plugin_manager import PluginManager
+from alchemist_py.project_manager import Manager
+from alchemist_py.tclgen import tclgen
+from alchemist_py.xdcgen import xdcgen
 
 def usage():
     operations = [

--- a/alchemist_py/project_manager.py
+++ b/alchemist_py/project_manager.py
@@ -9,9 +9,9 @@ import toml
 
 from pathlib import Path
 
-from alchemist.brokergen import createProject
-from alchemist.deviceinfo import searchDevice
-from alchemist.plugin_manager import PluginManager
+from alchemist_py.brokergen import createProject
+from alchemist_py.deviceinfo import searchDevice
+from alchemist_py.plugin_manager import PluginManager
 
 class Manager(object):
     def __init__(self):

--- a/alchemist_py/yacc.py
+++ b/alchemist_py/yacc.py
@@ -1,7 +1,7 @@
 import ply.yacc as yacc
 import sys
 
-from alchemist.lex import tokens
+from alchemist_py.lex import tokens
 
 def p_MESSAGE(p):
     'MESSAGE : PARAMS'

--- a/doc/en/Common.md
+++ b/doc/en/Common.md
@@ -1,0 +1,101 @@
+# Overview
+
+Alchemist is an tool for assisting component-oriented FPGA development.
+It builds a digital circuit combining circuit components which are written in software programming language (i.e. C-language).
+The components are synthesized into HDL (Hardware Description Language) and synthezied, placed and routed onto FPGA using FPGA tools.
+
+# Environment
+
+- OS: Ubuntu 18.04 LTS
+- Python 3.7>=
+- FPGA tools: Vivado, Vivado HLS (2019.2)
+- Fast RTPS (v1.7.2)
+
+# Installation
+
+## Fast RTPS
+
+### Dependency
+
+- g++, make
+- CMake
+- Git
+- JDK8
+- Gradle
+
+```
+$ sudo apt install build-essential cmake git openjdk-8-jdk gradle -y
+$ sudo apt install libncurses5 -y
+```
+
+### Fast-RTPS compilation and install
+
+```
+
+$ git clone https://github.com/eProsima/Fast-RTPS
+$ cd Fast-RTPS
+$ git checkout -b v1.7.2 remotes/origin/release/1.7.2
+$ mkdir bulid
+$ cd build
+$ cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON ..
+$ make -j8
+$ sudo make install
+```
+
+## Vivado, Vivado HLS
+
+Refer to [Vivado Design Suite User Guide UG973(v2019.1)](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2019_1/ug973-vivado-release-notes-install-license.pdf).
+
+## alchemist_py
+
+```
+$ git clone https://github.com/ohkawatks/alchemist_py
+$ cd alchemist_py
+$ sudo python setup.py install
+```
+
+# Uninstall
+
+## Fast RTPS
+
+```
+$ echo "fast-rtps install" | sudo dpkg --set-selections
+$ sudo apt remove --purge fast-rtps -y
+```
+
+## alchemist_py
+
+```
+$ sudo pip uninstall alchemist_py
+```
+
+# Preparation
+
+alchemist_py uses the configuration files and plugins located at `~/.alchemist/`.
+Here, the minimum setting required for the development using Vivado and VivadoHLS.
+
+- ~/.alchemist/config.toml
+
+```
+path_to_vivado="/path/to/Xilinx/Vivado/2019.2"
+
+[[plugins]]
+repo = 'Kenta11/Veaker_py'
+```
+
+- Directory
+
+```
+$ tree -L 1 .alchemist
+.alchemist
+├── config.toml
+└── plugins
+
+1 directory, 1 file
+```
+
+- Installation of Plugin (Veaker)
+
+```
+$ alchemist plugin install
+```

--- a/doc/jp/AlchemistCommonManual.md
+++ b/doc/jp/AlchemistCommonManual.md
@@ -35,13 +35,12 @@ $ sudo apt install build-essential cmake git openjdk-8-jdk gradle checkinstall -
 
 $ git clone https://github.com/eProsima/Fast-RTPS
 $ cd Fast-RTPS
-$ git checkout -b build v1.7.2
+$ git checkout -b v1.7.2 remotes/origin/release/1.7.2
 $ mkdir bulid
 $ cd build
 $ cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON ..
-$ make -j`grep processor /proc/cpuinfo | wc -l`
-$ sudo checkinstall --maintainer `whoami` --pkgname fast-rtps --default
-$ echo "fast-rtps hold" | sudo dpkg --get-selections
+$ make -j8
+$ sudo make install
 ```
 
 ## Vivado, Vivado HLS

--- a/doc/jp/AlchemistCommonManual.md
+++ b/doc/jp/AlchemistCommonManual.md
@@ -51,7 +51,7 @@ Refer to [Vivado Design Suite User Guide UG973(v2019.1)](https://www.xilinx.com/
 ## alchemist
 
 ```
-$ sudo pip install https://github.com/Kenta11/alchemist
+$ sudo pip install https://github.com/ohkawatks/alchemist_py
 ```
 
 # アンインストール

--- a/doc/jp/AlchemistCommonManual.md
+++ b/doc/jp/AlchemistCommonManual.md
@@ -7,7 +7,7 @@ alchemistはコンポーネント指向によるFPGA開発のための支援ツ�
 
 # 開発環境
 
-- OS: Ubuntu 18.04 LTS
+- OS: Ubuntu 20.04 LTS
 - Python 3.7>=
 - FPGA 開発ツール: Vivado, Vivado HLS (2019.1)
 - Fast RTPS (v1.7.2)

--- a/doc/jp/AlchemistCommonManual.md
+++ b/doc/jp/AlchemistCommonManual.md
@@ -27,6 +27,7 @@ alchemistはコンポーネント指向によるFPGA開発のための支援ツ�
 
 ```
 $ sudo apt install build-essential cmake git openjdk-8-jdk gradle checkinstall -y
+$ sudo apt install libncurses5 -y
 ```
 
 ### Fast-RTPSのコンパイルとインストール

--- a/doc/jp/AlchemistCommonManual.md
+++ b/doc/jp/AlchemistCommonManual.md
@@ -7,7 +7,7 @@ alchemistはコンポーネント指向によるFPGA開発のための支援ツ�
 
 # 開発環境
 
-- OS: Ubuntu 20.04 LTS
+- OS: Ubuntu 18.04 LTS
 - Python 3.7>=
 - FPGA 開発ツール: Vivado, Vivado HLS (2019.1)
 - Fast RTPS (v1.7.2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ install_requires =
     logzero
     numpy
     toml
+    ply
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The old package name "alchemist" is causing a problem.
In the installation instruction, the "checkinstall" does not work in my environment (Ubuntu18.04). So it is changed to more general "make install".